### PR TITLE
Add dev script alias for ng serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve -o",
+    "dev": "ng serve -o",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
Added "dev" script as an alias for "ng serve -o" to provide a more standardized development command that aligns with common practices across JavaScript projects.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=zen-sanctuary&projectId=274d3910a4c54cbeb03aa6453bf0e025)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d3910a4c54cbeb03aa6453bf0e025</projectId>-->